### PR TITLE
Fix panic when remote_ip_prefix doesnt not exists.

### DIFF
--- a/gcore/utils.go
+++ b/gcore/utils.go
@@ -510,7 +510,10 @@ func secGroupUniqueID(i interface{}) int {
 	io.WriteString(h, strconv.Itoa(e["port_range_min"].(int)))
 	io.WriteString(h, strconv.Itoa(e["port_range_max"].(int)))
 	io.WriteString(h, e["description"].(string))
-	io.WriteString(h, e["remote_ip_prefix"].(string))
+
+	if p, ok := e["remote_ip_prefix"].(string); ok {
+		io.WriteString(h, p)
+	}
 
 	return int(binary.BigEndian.Uint64(h.Sum(nil)))
 }


### PR DESCRIPTION
Steps to reproduce:

terraform.tf
```
terraform {
  required_version = ">= 0.13.0"
  required_providers {
    gcore = {
      source  = "g-core/gcorelabs"
      version = "0.1.14"
    }
  }
}

provider gcore {
  user_name = "04us04@gcore.wgprod.net"
  password = "password"
  gcore_platform = "https://api.gcdn.co"
  gcore_api = "https://api.cloud.gcorelabs.com"
}

//13930
data "gcore_project" "platform" {
  name = "wg-platform"
}

//6
data "gcore_region" "ed" {
  name = "Luxembourg"
}

data "gcore_securitygroup" "default" {
  name = "default"

  region_id = data.gcore_region.ed.id
  project_id = data.gcore_project.platform.id
}

output "view" {
  value = data.gcore_securitygroup.default
}
```

Raise panic:

```
2021-05-04T20:14:37.001+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] Start SecurityGroup reading: timestamp=2021-05-04T20:14:37.001+0300
2021-05-04T20:14:37.001+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] Try to get project ID: timestamp=2021-05-04T20:14:37.001+0300
2021-05-04T20:14:37.001+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] Start Network reading: timestamp=2021-05-04T20:14:37.001+0300
2021-05-04T20:14:37.001+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] Try to get project ID: timestamp=2021-05-04T20:14:37.001+0300
2021-05-04T20:14:37.001+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] Try to get project ID: timestamp=2021-05-04T20:14:37.001+0300
2021-05-04T20:14:37.020+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] Regions: [{6 Luxembourg ED-9 ACTIVE <nil> public f2cce7b9-d7c9-494c-9b0a-20a57137933c https://console-spice-ed9.cloud.gcorelabs.com/ {2020-10-12 09:37:01 +0000 UTC} 6 {6 https://ed-9.cloud.core.pw:5000/v3 NEW 4abc5230958747ddb4e8687f013ac06c {2019-08-23 17:06:29 +0000 UTC} ******}} {10 Moscow DT-2 ACTIVE <nil> public b8ca9ce8-ba2c-4cae-b13c-ab054fe68572 https://console-spice-dt2.cloud.gcorelabs.com/ {2020-10-12 09:38:41 +0000 UTC} 2 {2 https://dt-2.cloud.core.pw:5000/v3 NEW 8a7c50df9400465485c5d1916928e99e {2020-02-06 13:54:21 +0000 UTC} ******}} {14 Manassas ANX-2 ACTIVE <nil> public d9611ca8-6dd2-4224-9237-b1fd0ef5c536 https://console-spice-anx2.cloud.gcorelabs.com/ {2020-10-12 09:38:57 +0000 UTC} 14 {14 https://anx-2.cloud.gc.onl:5000/v3 NEW b3041685e84d41acbc70e118ab011520 {2020-07-31 12:14:03 +0000 UTC} ******}} {18 Singapore SGC-2 ACTIVE <nil> public edced6c8-4a17-4c64-a283-0e2b9621fe9b https://console-spice-sgc2.cloud.gcorelabs.com/ {2020-11-30 11:51:34 +0000 UTC} 18 {18 https://sgc-2.cloud.gc.onl:5000/v3 NEW e4dcf03fc8e548a3adac26d1df5cb0d0 {2020-11-30 11:47:30 +0000 UTC} ******}} {22 Khabarovsk RC-2 ACTIVE <nil> public 6c950d50-67d6-4efb-b8de-75120d7b1b31 https://console-spice-rc2.cloud.gcorelabs.com/ {2021-02-02 09:18:40 +0000 UTC} 22 {22 https://rc-2.cloud.gc.onl:35357/v3 NEW 3460862d9efb4d83869f83bd6befa89e {2021-02-02 09:13:49 +0000 UTC} ******}} {26 Amsterdam DRA4-2 ACTIVE <nil> public 6ff50ee4-63f2-44e7-a93c-3982c02a4888 https://console-spice-dra42.cloud.gcorelabs.com/ {2021-03-10 09:32:40 +0000 UTC} 26 {26 https://dra4-2.cloud.gc.onl:5000/v3 NEW a8a3a2435bf64966a069531b1b8db559 {2021-03-10 09:24:18 +0000 UTC} ******}} {30 Tokyo CC1-2 ACTIVE <nil> public 280fdeee-8443-4080-a1d2-6814b9a55d9a  {2021-04-27 11:22:00 +0000 UTC} 30 {30 https://cc1-2.cloud.gc.onl:35357/v3 NEW 97711b09f904400e9be77375d5dd6d25 {2021-04-27 11:21:22 +0000 UTC} ******}} {34 Santa Clara SCL2-2 ACTIVE <nil> public ee7928d3-9437-4b15-92d9-c283dec22d37  {2021-04-27 11:25:37 +0000 UTC} 34 {34 https://scl2-2.cloud.gc.onl:35357/v3 NEW b74d069d8da14121a31a11e220042d87 {2021-04-27 11:24:37 +0000 UTC} ******}}]: timestamp=2021-05-04T20:14:37.020+0300
2021-05-04T20:14:37.020+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] The attempt to get the region is successful: regionID=14: timestamp=2021-05-04T20:14:37.020+0300
2021-05-04T20:14:37.020+0300 [INFO]  provider.terraform-provider-gcorelabs_v0.1.14: 2021/05/04 20:14:37 [DEBUG] Finish Region reading: timestamp=2021-05-04T20:14:37.020+0300
2021-05-04T20:14:37.773+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: PANIC: interface conversion: interface {} is nil, not string
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14:
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: goroutine 79 [running]:
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/terraform-providers/terraform-provider-gcorelabs/gcore.secGroupUniqueID(0x100bf3ae0, 0x1400020bec0, 0x100ce92a8)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/terraform-providers/terraform-provider-gcorelabs/gcore/utils.go:513 +0x568
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).hash(0x140008f04c0, 0x100bf3ae0, 0x1400020bec0, 0x140002658c0, 0x1284b6428)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/set.go:251 +0x3c
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).add(0x140008f04c0, 0x100bf3ae0, 0x1400020bec0, 0x1400020bf00, 0x140002fb628, 0x100a13c64)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/set.go:231 +0x5c
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).Add(...)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/set.go:75
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.NewSet(0x100ce7278, 0x14000192540, 0x4, 0x4, 0x14000085bc8)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/set.go:62 +0xa0
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/terraform-providers/terraform-provider-gcorelabs/gcore.dataSourceSecurityGroupRead(0x100d0e4a8, 0x140001a2840, 0x14000a18280, 0x100b97f00, 0x14000290048, 0x14000407ca0, 0x140002fb928, 0x10093e678)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/terraform-providers/terraform-provider-gcorelabs/gcore/data_source_gcore_securitygroup.go:190 +0x824
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x140004d89c0, 0x100d0e438, 0x1400026b100, 0x14000a18280, 0x100b97f00, 0x14000290048, 0x0, 0x0, 0x0)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/resource.go:297 +0x17c
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0x140004d89c0, 0x100d0e438, 0x1400026b100, 0x140007c8d00, 0x100b97f00, 0x14000290048, 0x14000290048, 0x140007c8d00, 0x0, 0x0)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/resource.go:498 +0xcc
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0x1400000d338, 0x100d0e438, 0x1400026b100, 0x140007c89c0, 0x1400026b100, 0x100859bac, 0x100c763e0)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-sdk/v2@v2.4.3/helper/schema/grpc_provider.go:1105 +0x3dc
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadDataSource(0x14000079640, 0x100d0e4e0, 0x1400026b100, 0x140007244b0, 0x14000079640, 0x1007c8d20, 0x100c7c400)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/server/server.go:247 +0xc4
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler(0x100ca8560, 0x14000079640, 0x100d0e4e0, 0x1400018ea80, 0x140001a2720, 0x0, 0x100d0e4e0, 0x1400018ea80, 0x140001f8120, 0x87)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	github.com/hashicorp/terraform-plugin-go@v0.2.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:416 +0x1c8
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: google.golang.org/grpc.(*Server).processUnaryRPC(0x140001fae00, 0x100d15f78, 0x1400008be00, 0x140000a6900, 0x14000096810, 0x1011861f0, 0x0, 0x0, 0x0)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	google.golang.org/grpc@v1.32.0/server.go:1194 +0x3e8
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: google.golang.org/grpc.(*Server).handleStream(0x140001fae00, 0x100d15f78, 0x1400008be00, 0x140000a6900, 0x0)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	google.golang.org/grpc@v1.32.0/server.go:1517 +0xa50
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: google.golang.org/grpc.(*Server).serveStreams.func1.2(0x140004b83c0, 0x140001fae00, 0x100d15f78, 0x1400008be00, 0x140000a6900)
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	google.golang.org/grpc@v1.32.0/server.go:859 +0x94
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: created by google.golang.org/grpc.(*Server).serveStreams.func1
2021-05-04T20:14:37.774+0300 [DEBUG] provider.terraform-provider-gcorelabs_v0.1.14: 	google.golang.org/grpc@v1.32.0/server.go:857 +0x1f8
2021-05-04T20:14:37.777+0300 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/g-core/gcorelabs/0.1.14/darwin_arm64/terraform-provider-gcorelabs_v0.1.14 pid=17192 error="exit status 2"
2021-05-04T20:14:37.778+0300 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"
2021-05-04T20:14:37.778+0300 [ERROR] plugin.(*GRPCProvider).ReadDataSource: error="rpc error: code = Unavailable desc = transport is closing"
2021-05-04T20:14:37.778+0300 [ERROR] plugin.(*GRPCProvider).ReadDataSource: error="rpc error: code = Unavailable desc = transport is closing"
```