### PR TITLE
support 'permanent_api_token' for CDN terraform resources

### DIFF
--- a/gcore/provider.go
+++ b/gcore/provider.go
@@ -186,7 +186,10 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	}
 
 	cdnProvider := gcdnProvider.NewClient(cdnAPI, gcdnProvider.WithSignerFunc(func(req *http.Request) error {
-		req.Header.Set("Authorization", "Bearer "+provider.AccessToken())
+		for k, v := range provider.AuthenticatedHeaders() {
+			req.Header.Set(k, v)
+		}
+
 		return nil
 	}))
 	cdnService := gcdn.NewService(cdnProvider)


### PR DESCRIPTION
add support for PERM TOKEN for CDN resources:

```
provider gcore {
  permanent_api_token ="<PERM_API_TOKEN>"
  gcore_platform = "https://api.gcdn.co"
  gcore_cdn_api = "https://api.gcdn.co"
}
```